### PR TITLE
Fix interaction with black commemoration banner

### DIFF
--- a/theme.user.js
+++ b/theme.user.js
@@ -93,12 +93,24 @@ function start() {
     myJQuery('.comhead > a').css('color', config.comheadLinksColor);
 
     //// Bar at top
-    myJQuery('tr:eq(0)').next().html(config.topBarText);
-    myJQuery('tr:eq(0)').next().css('background-color', config.topBarColor);
-  }  else {
+    if (myJQuery('tr:first-child').has('td[bgcolor="#000000"]').length) {
+        // Check for black bar
+        myJQuery('tr:eq(1)').next().html(config.topBarText);
+        myJQuery('tr:eq(1)').next().css('background-color', config.topBarColor);
+    } else {
+        myJQuery('tr:eq(0)').next().html(config.topBarText);
+        myJQuery('tr:eq(0)').next().css('background-color', config.topBarColor);
+    }
+  } else {
     //// Bar at top
-    myJQuery('tr:eq(0)').next().html(config.topBarText);
-    myJQuery('tr:eq(0)').next().css('background-color', config.topBarColor);
+    if (myJQuery('tr:first-child').has('td[bgcolor="#000000"]').length) {
+        // Check for black bar
+        myJQuery('tr:eq(1)').next().html(config.topBarText);
+        myJQuery('tr:eq(1)').next().css('background-color', config.topBarColor);
+    } else {
+        myJQuery('tr:eq(0)').next().html(config.topBarText);
+        myJQuery('tr:eq(0)').next().css('background-color', config.topBarColor);
+    }
   }
 
   //// Footer

--- a/theme.user.js
+++ b/theme.user.js
@@ -3,7 +3,7 @@
 // @namespace         https://github.com/dparpyani
 // @description       A dark theme for Hacker News (YCombinator).
 // @include           https://news.ycombinator.com*
-// @require           https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js
+// @require           https://ajax.googleapis.com/ajax/libs/jquery/3.6.3/jquery.min.js
 // @grant             none
 // @version           1.1
 // ==/UserScript==

--- a/theme.user.js
+++ b/theme.user.js
@@ -5,7 +5,7 @@
 // @include           https://news.ycombinator.com*
 // @require           https://ajax.googleapis.com/ajax/libs/jquery/3.6.3/jquery.min.js
 // @grant             none
-// @version           1.1
+// @version           1.2
 // ==/UserScript==
 
 var loadScript = function (src, callback) {


### PR DESCRIPTION
In case someone important dies, HN adds a black bar to the top of the page. This causes the title menu to no longer be the first table row. The dark mode then simply removes the title bar.
This pull request adds a simple check if the first table row is completely black. In such cases it applies the dark mode to the second table row instead.
Additionally I upgraded the script to the latest jQuery version.